### PR TITLE
Add support for storing the user's selected mode in UserDefaults.

### DIFF
--- a/Thock.xcodeproj/project.pbxproj
+++ b/Thock.xcodeproj/project.pbxproj
@@ -1217,7 +1217,9 @@
 				7762F4AE2D7A83BC0033AE42 /* ThockUITests */,
 				7762F4912D7A83BA0033AE42 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		7762F4912D7A83BA0033AE42 /* Products */ = {
 			isa = PBXGroup;

--- a/Thock/Managers/ModeManager.swift
+++ b/Thock/Managers/ModeManager.swift
@@ -7,18 +7,30 @@
 
 import Foundation
 
-class ModeManager {
+final class ModeManager {
     static let shared = ModeManager()
-    
-    private var currentMode: Mode = ModeDatabase().getMode(
-        by: UUID(uuidString: "8f6a8074-e5a5-49f3-b3e9-f9f735b98476")!
-    )!
-    
+    private static let defaultId: UUID = UUID(uuidString: "8f6a8074-e5a5-49f3-b3e9-f9f735b98476")!
+    private var currentMode: Mode = ModeDatabase().getMode(by: (UserDefaults.standard.currentMode ?? ModeManager.defaultId))!
+
     func setCurrentMode(_ newMode: Mode) {
         currentMode = newMode
+        UserDefaults.standard.currentMode = newMode.id
     }
     
     func getCurrentMode() -> Mode {
         return currentMode
+    }
+}
+
+private extension UserDefaults {
+    var currentMode: UUID? {
+        get {
+            if let string = string(forKey: "currentMode") {
+                UUID(uuidString: string)
+            } else {
+                nil
+            }
+        }
+        set { set(newValue?.uuidString, forKey: "currentMode") }
     }
 }


### PR DESCRIPTION
This PR adds a feature to save the current mode in `UserDefaults` so that it's automatically restored when the app starts again.

It also sets the indentation and tab width to 4 spaces. I usually use 2 spaces in my projects, so it's great that the project itself sets the rules instead of letting Xcode decide.