### PR TITLE
feat: add support for external sh script control

### DIFF
--- a/Thock.xcodeproj/project.pbxproj
+++ b/Thock.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		777D591E2D7B0B7600A1B71F /* Exceptions for "Thock" folder in "Thock" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Info.plist,
 				"Preview Content/Preview Assets.xcassets",
 				Resources/Sounds/Alps/tplai/SKCM_Blue/1.mp3,
 				Resources/Sounds/Alps/tplai/SKCM_Blue/2.mp3,
@@ -1542,6 +1543,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Thock/Info.plist;
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1572,6 +1574,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Thock/Info.plist;
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Thock/AppDelegate.swift
+++ b/Thock/AppDelegate.swift
@@ -10,18 +10,36 @@ import AppKit
 
 class AppDelegate: NSObject, NSApplicationDelegate, MenuBarControllerDelegate {
     private var statusBarItem: NSStatusItem!
-    private var menuManager: MenuBarController!
+    private var menuBarController: MenuBarController!
     private var keyTracker: KeyTracker!
+    
+    // MARK: - App Lifecycle
     
     func applicationDidFinishLaunching(_ notification: Notification) {
         guard requestAccessibilityPermissions() else {
             exit(1)
         }
         
+        _ = PipeListenerService.shared
         initializeKeyTracker()
-        loadInitialModeConfig()
+        
+        ModeEngine.shared.loadInitialMode()
         setupMenuBar()
     }
+    
+    /// Quits the application cleanly.
+    func applicationWillTerminate(_ notification: Notification) {
+        keyTracker?.stopTrackingKeys()
+        PipeListenerService.shared.cleanUp()
+    }
+    
+    // MARK: - MenuBarControllerDelegate
+    
+    func quitApp() {
+        NSApplication.shared.terminate(nil)
+    }
+    
+    // MARK: - Setup Methods
     
     /// Checks and requests accessibility permissions.
     private func requestAccessibilityPermissions() -> Bool {
@@ -32,34 +50,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, MenuBarControllerDelegate {
     
     /// Initializes and starts tracking keyboard events.
     private func initializeKeyTracker() {
-        keyTracker = KeyTracker()
-        keyTracker.startTrackingKeys()
-    }
-    
-    /// Loads the current mode’s configuration.
-    private func loadInitialModeConfig() {
-        let currentMode = ModeManager.shared.getCurrentMode()
-        ModeConfigManager.shared.loadModeConfig(for: currentMode)
-        SoundManager.shared.preloadSounds(for: currentMode)
+        if keyTracker == nil {
+            keyTracker = KeyTracker()
+            keyTracker.startTrackingKeys()
+        }
     }
     
     /// Sets up the macOS menu bar.
     private func setupMenuBar() {
         statusBarItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        menuManager = MenuBarController(statusBarItem: statusBarItem, delegate: self)
-        menuManager.updateMenuBarIcon()
-    }
-    
-    /// Changes the sound mode.
-    func changeMode(to mode: Mode) {
-        ModeManager.shared.setCurrentMode(mode)
-        ModeConfigManager.shared.loadModeConfig(for: mode)
-        SoundManager.shared.preloadSounds(for: mode)
-    }
-    
-    /// Quits the application cleanly.
-    func quitApp() {
-        keyTracker?.stopTrackingKeys()
-        NSApplication.shared.terminate(nil)
+        menuBarController = MenuBarController(statusBarItem: statusBarItem, delegate: self)
+        menuBarController.updateMenuBarIcon(for: AppEngine.shared.isEnabled())
     }
 }
+

--- a/Thock/Engines/AppEngine.swift
+++ b/Thock/Engines/AppEngine.swift
@@ -1,0 +1,30 @@
+//
+//  AppEngine.swift
+//  Thock
+//
+//  Created by Kamil Łobiński on 29/03/2025.
+//
+
+import Foundation
+
+final class AppEngine {
+    static let shared = AppEngine()
+    
+    private init() {}
+    
+    func toggleIsEnabled() -> Bool {
+        print("Toggle enabled")
+        return setEnabled(!isEnabled())
+    }
+    
+    func isEnabled() -> Bool {
+        //        print("Get enabled: \(AppStateManager.shared.isEnabled)")
+        return AppStateManager.shared.isEnabled
+    }
+    
+    func setEnabled(_ enabled: Bool) -> Bool {
+        print("Set enabled: \(enabled)")
+        AppStateManager.shared.isEnabled = enabled
+        return enabled
+    }
+}

--- a/Thock/Engines/ModeEngine.swift
+++ b/Thock/Engines/ModeEngine.swift
@@ -1,0 +1,44 @@
+//
+//  ModeEngine.swift
+//  Thock
+//
+//  Created by Kamil Łobiński on 28/03/2025.
+//
+
+import Foundation
+
+final class ModeEngine {
+    static let shared = ModeEngine()
+    
+    private init() {}
+    
+    func apply(mode: Mode) {
+        print("Apply mode: \(mode.name)")
+        ModeManager.shared.setCurrentMode(mode)
+        ModeConfigManager.shared.loadModeConfig(for: mode)
+        SoundEngine.shared.preloadSounds(for: mode)
+        SettingsEngine.shared.refreshMenu()
+    }
+    
+    func loadInitialMode() {
+        print("Load initial mode config")
+        let mode = ModeManager.shared.getCurrentMode()
+        ModeConfigManager.shared.loadModeConfig(for: mode)
+        SoundEngine.shared.preloadSounds(for: mode)
+    }
+    
+    func getKeyDownSounds(for key: String) -> [String] {
+        print("Get key down sounds for \(key)")
+        return ModeConfigManager.shared.getKeyDownSounds(for: key)
+    }
+    
+    func getKeyUpSounds(for key: String) -> [String] {
+        print("Get key up sounds for \(key)")
+        return ModeConfigManager.shared.getKeyUpSounds(for: key)
+    }
+    
+    func getModeCurrentMode() -> Mode {
+        print("Get current mode")
+        return ModeManager.shared.getCurrentMode()
+    }
+}

--- a/Thock/Engines/SettingsEngine.swift
+++ b/Thock/Engines/SettingsEngine.swift
@@ -1,0 +1,65 @@
+//
+//  SettingsEngine.swift
+//  Thock
+//
+//  Created by Kamil Łobiński on 28/03/2025.
+//
+
+import Foundation
+
+final class SettingsEngine {
+    static let shared = SettingsEngine()
+    
+    private init() {}
+    
+    func toggleOpenAtLogin() -> Bool {
+        print("Toggle open at login")
+        let newState = !SettingsManager.shared.openAtLogin
+        SettingsManager.shared.openAtLogin = newState
+        OpenAtLoginManager.setEnabled(newState)
+        return newState
+    }
+    
+    func isOpenAtLoginEnabled() -> Bool {
+        print("Get open at login state")
+        return SettingsManager.shared.openAtLogin
+    }
+    
+    func toggleModifierKeySound() -> Bool {
+        print("Toggle sound modifier keys")
+        let newState = !SettingsManager.shared.disableModifierKeys
+        SettingsManager.shared.disableModifierKeys = newState
+        return newState
+    }
+    
+    func isModifierKeySoundDisabled() -> Bool {
+        print("Get sound modifier keys state")
+        return SettingsManager.shared.disableModifierKeys
+    }
+    
+    func selectMode(mode: Mode) {
+        print("Select mode: \(mode)")
+        ModeEngine.shared.apply(mode: mode)
+    }
+    
+    func refreshMenu() {
+        print("Refresh menu")
+        NotificationCenter.default.post(name: .settingsDidChange, object: nil)
+    }
+    
+    func toggleIgnoreRapidKeyEvents() -> Bool {
+        print("Toggle ignore rapid key events")
+        let newState = !SettingsManager.shared.ignoreRapidKeyEvents
+        SettingsManager.shared.ignoreRapidKeyEvents = newState
+        return newState
+    }
+    
+    func isIgnoreRapidKeyEventsEnabled() -> Bool {
+        print("Get ignore rapid key events state")
+        return SettingsManager.shared.ignoreRapidKeyEvents
+    }
+}
+
+extension Notification.Name {
+    static let settingsDidChange = Notification.Name("settingsDidChange")
+}

--- a/Thock/Engines/SoundEngine.swift
+++ b/Thock/Engines/SoundEngine.swift
@@ -1,0 +1,52 @@
+//
+//  SoundEngine.swift
+//  Thock
+//
+//  Created by Kamil Łobiński on 29/03/2025.
+//
+
+import Foundation
+
+final class SoundEngine {
+    static let shared = SoundEngine()
+    
+    private init() {}
+    
+    func preloadSounds(for mode: Mode) {
+        print("Preload sounds")
+        SoundManager.shared.preloadSounds(for: mode)
+    }
+    
+    /// Plays sound for a key press event.
+    func play(for keyCode: Int64, isKeyDown: Bool) {
+        guard AppEngine.shared.isEnabled() else { return }
+        print("Play sound for keyCode: \(keyCode)")
+        
+        let keyType = KeyMapper.fromKeyCode(keyCode)
+        let keySoundList = isKeyDown
+        ? ModeEngine.shared.getKeyDownSounds(for: keyType)
+        : ModeEngine.shared.getKeyUpSounds(for: keyType)
+        
+        if let soundFileName = keySoundList.randomElement() {
+            play(sound: soundFileName)
+        } else {
+            // print("Warning: (keydown: \(isKeyDown)) No available sound for keyCode: \(keyCode)")
+        }
+    }
+    
+    func play(sound name: String) {
+        print("Play sound: \(name)")
+        SoundManager.shared.play(sound: name)
+    }
+    
+    func setVolume(_ volume: Float) {
+        print("Set volume: \(volume)")
+        SoundManager.shared.setVolume(volume)
+    }
+    
+    func getVolume() -> Float {
+        print("Get volume")
+        return SoundManager.shared.getVolume()
+    }
+    
+}

--- a/Thock/Info.plist
+++ b/Thock/Info.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+    </dict>
+</plist>

--- a/Thock/Managers/ModeManager.swift
+++ b/Thock/Managers/ModeManager.swift
@@ -11,7 +11,7 @@ final class ModeManager {
     static let shared = ModeManager()
     private static let defaultId: UUID = UUID(uuidString: "8f6a8074-e5a5-49f3-b3e9-f9f735b98476")!
     private var currentMode: Mode = ModeDatabase().getMode(by: (UserDefaults.standard.currentMode ?? ModeManager.defaultId))!
-
+    
     func setCurrentMode(_ newMode: Mode) {
         currentMode = newMode
         UserDefaults.standard.currentMode = newMode.id

--- a/Thock/Managers/OpenAtLoginManager.swift
+++ b/Thock/Managers/OpenAtLoginManager.swift
@@ -15,7 +15,7 @@ enum OpenAtLoginManager {
     private static var appService: SMAppService {
         SMAppService.mainApp
     }
-
+    
     /// Registers or unregisters the app as a login item based on the user's preference.
     /// - Parameter enabled: If `true`, app is added to login items. If `false`, it's removed.
     static func setEnabled(_ enabled: Bool) {
@@ -29,7 +29,7 @@ enum OpenAtLoginManager {
             print("Failed to \(enabled ? "enable" : "disable") login item: \(error.localizedDescription)")
         }
     }
-
+    
     /// Returns whether the app is currently set to launch at login.
     static func isEnabled() -> Bool {
         return appService.status == .enabled

--- a/Thock/Managers/SettingsManager.swift
+++ b/Thock/Managers/SettingsManager.swift
@@ -12,23 +12,30 @@ final class SettingsManager {
     static let shared = SettingsManager()
     static let defaultOpenAtLogin: Bool = false
     static let defaultDisableModifierKeys: Bool = false
+    static let defaultIgnoreRapidKeyEvents: Bool = false
+    
     
     private init() {}
-
+    
     /// Whether the app should launch at login.
     /// Automatically updates the system login item registration.
     var openAtLogin: Bool {
         get { UserDefaults.openAtLogin }
         set {
             UserDefaults.openAtLogin = newValue
-            OpenAtLoginManager.setEnabled(newValue)
         }
     }
-
+    
     /// Whether modifier keys should be ignored in sound playback.
     var disableModifierKeys: Bool {
         get { UserDefaults.disableModifierKeys }
         set { UserDefaults.disableModifierKeys = newValue }
+    }
+    
+    /// Whether to filter out key events that occur too rapidly in succession.
+    var ignoreRapidKeyEvents: Bool {
+        get { UserDefaults.ignoreRapidKeyEvents }
+        set { UserDefaults.ignoreRapidKeyEvents = newValue }
     }
 }
 
@@ -36,8 +43,9 @@ private extension UserDefaults {
     private enum Keys {
         static let openAtLogin = "openAtLogin"
         static let disableModifierKeys = "disableModifierKeys"
+        static let ignoreRapidKeyEvents = "ignoreRapidKeyEvents"
     }
-
+    
     static var openAtLogin: Bool {
         get {
             if standard.object(forKey: Keys.openAtLogin) == nil {
@@ -49,7 +57,7 @@ private extension UserDefaults {
             standard.set(newValue, forKey: Keys.openAtLogin)
         }
     }
-
+    
     static var disableModifierKeys: Bool {
         get {
             if standard.object(forKey: Keys.disableModifierKeys) == nil {
@@ -59,6 +67,18 @@ private extension UserDefaults {
         }
         set {
             standard.set(newValue, forKey: Keys.disableModifierKeys)
+        }
+    }
+    
+    static var ignoreRapidKeyEvents: Bool {
+        get {
+            if standard.object(forKey: Keys.ignoreRapidKeyEvents) == nil {
+                return SettingsManager.defaultIgnoreRapidKeyEvents
+            }
+            return standard.bool(forKey: Keys.ignoreRapidKeyEvents)
+        }
+        set {
+            standard.set(newValue, forKey: Keys.ignoreRapidKeyEvents)
         }
     }
 }

--- a/Thock/Models/ModeDatabase.swift
+++ b/Thock/Models/ModeDatabase.swift
@@ -24,49 +24,49 @@ struct ModeDatabase {
                 Mode(
                     id: UUID(uuidString: "113f785e-0a0a-4300-9525-865654c619aa")!,
                     name: "Black ABS",
-                    isNew: true,
+                    isNew: false,
                     path: "Resources/Sounds/Cherry_MX/mechvibes/Black_ABS/"
                 ),
                 Mode(
                     id: UUID(uuidString: "eb2d732c-9777-4b2f-b132-b1da5f735ebb")!,
                     name: "Black PBT",
-                    isNew: true,
+                    isNew: false,
                     path: "Resources/Sounds/Cherry_MX/mechvibes/Black_PBT/"
                 ),
                 Mode(
                     id: UUID(uuidString: "25f28ac0-62f1-4e9d-bc68-f7f85d6ef35a")!,
                     name:"Blue ABS",
-                    isNew: true,
+                    isNew: false,
                     path: "Resources/Sounds/Cherry_MX/mechvibes/Blue_ABS/"
                 ),
                 Mode(
                     id: UUID(uuidString: "0b4e19ba-6a22-41eb-a9ef-ac0571181b52")!,
                     name: "Blue PBT",
-                    isNew: true,
+                    isNew: false,
                     path: "Resources/Sounds/Cherry_MX/mechvibes/Blue_PBT/"
                 ),
                 Mode(
                     id: UUID(uuidString: "c9bcdb8f-50c1-4438-830f-67eeeeb40ea2")!,
                     name: "Brown ABS",
-                    isNew: true,
+                    isNew: false,
                     path: "Resources/Sounds/Cherry_MX/mechvibes/Brown_ABS/"
                 ),
                 Mode(
                     id: UUID(uuidString: "83d8416b-2dc0-47fb-ac02-e5495c547244")!,
                     name: "Brown PBT",
-                    isNew: true,
+                    isNew: false,
                     path: "Resources/Sounds/Cherry_MX/mechvibes/Brown_PBT/"
                 ),
                 Mode(
                     id: UUID(uuidString: "ea69d01e-e83e-4186-a122-72ebfb7d620e")!,
                     name: "Red ABS",
-                    isNew: true,
+                    isNew: false,
                     path: "Resources/Sounds/Cherry_MX/mechvibes/Red_ABS/"
                 ),
                 Mode(
                     id: UUID(uuidString: "313554e8-8440-45f9-84ab-799bb1e4217f")!,
                     name: "Red PBT",
-                    isNew: true,
+                    isNew: false,
                     path: "Resources/Sounds/Cherry_MX/mechvibes/Red_PBT/"
                 ),
             ],
@@ -116,13 +116,13 @@ struct ModeDatabase {
                 Mode(
                     id: UUID(uuidString: "e91d2da9-1a7f-40ee-af3e-928090ba217a")!,
                     name: "Crystal Purple",
-                    isNew: true,
+                    isNew: false,
                     path: "Resources/Sounds/Everglide/mechvibes/Crystal_Purple/"
                 ),
                 Mode(
                     id: UUID(uuidString: "ec6eb0ba-10d3-4c60-a521-c7747e6e39ab")!,
                     name: "Oreo",
-                    isNew: true,
+                    isNew: false,
                     path: "Resources/Sounds/Everglide/mechvibes/Oreo/"
                 ),
             ]
@@ -174,7 +174,7 @@ struct ModeDatabase {
                 Mode(
                     id: UUID(uuidString: "4c48615c-4765-4785-9dc6-1196ed4b8796")!,
                     name: "Purple Hybrid PBT",
-                    isNew: true,
+                    isNew: false,
                     path: "Resources/Sounds/Topre/mechvibes/Purple_Hybrid_PBT/"
                 ),
             ],
@@ -237,6 +237,31 @@ struct ModeDatabase {
             }
         }
         return nil
+    }
+    
+    func getMode(byName name: String, author: Author, brand: Brand) -> Mode? {
+        guard let authorModes = modeStorage[brand]?[author] else { return nil }
+        return authorModes.first { $0.name.caseInsensitiveCompare(name) == .orderedSame }
+    }
+    
+    func getMode(byName name: String, authorName: String, brandName: String) -> Mode? {
+        func normalize(_ string: String) -> String {
+            return string.lowercased().replacingOccurrences(of: " ", with: "")
+        }
+        
+        let normalizedName = normalize(name)
+        let normalizedAuthorName = normalize(authorName)
+        let normalizedBrandName = normalize(brandName)
+        
+        guard let author = Author.allCases.first(where: { normalize($0.rawValue) == normalizedAuthorName }) else {
+            return nil
+        }
+        
+        guard let brand = Brand.allCases.first(where: { normalize($0.rawValue) == normalizedBrandName }) else {
+            return nil
+        }
+        
+        return getMode(byName: normalizedName, author: author, brand: brand)
     }
     
     func getBrand(for mode: Mode) -> Brand? {

--- a/Thock/Services/KeyTracker.swift
+++ b/Thock/Services/KeyTracker.swift
@@ -11,7 +11,7 @@ class KeyTracker {
     private var pressedKeys: Set<Int64> = []
     private var eventMonitor: CFMachPort?
     private var lastEventTime: Double = 0
-
+    
     deinit {
         stopTrackingKeys()
     }
@@ -28,7 +28,7 @@ class KeyTracker {
         
         let observer = Unmanaged.passRetained(self).toOpaque()
         lastEventTime = currentTime()
-
+        
         eventMonitor = CGEvent.tapCreate(
             tap: .cghidEventTap,
             place: .tailAppendEventTap,
@@ -37,38 +37,40 @@ class KeyTracker {
             callback: { _, type, event, userInfo in
                 let keyTracker = Unmanaged<KeyTracker>.fromOpaque(userInfo!).takeUnretainedValue()
                 let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
-
-                // Ignore events that are too close to each other.
-                defer { keyTracker.lastEventTime = keyTracker.currentTime() }
-                let currentTimestamp = keyTracker.currentTime()
-                let elapsedTime = currentTimestamp - keyTracker.lastEventTime
-                if elapsedTime <= 10 { return Unmanaged.passUnretained(event) }
-
+                
+                if SettingsEngine.shared.isIgnoreRapidKeyEventsEnabled() {
+                    // Ignore events that are too close to each other.
+                    defer { keyTracker.lastEventTime = keyTracker.currentTime() }
+                    let currentTimestamp = keyTracker.currentTime()
+                    let elapsedTime = currentTimestamp - keyTracker.lastEventTime
+                    if elapsedTime <= 10 { return Unmanaged.passUnretained(event) }
+                }
+                
                 switch type {
                 case .keyDown where !keyTracker.pressedKeys.contains(keyCode):
                     keyTracker.pressedKeys.insert(keyCode)
-                    SoundManager.shared.playSound(for: keyCode, isKeyDown: true)
-
+                    SoundEngine.shared.play(for: keyCode, isKeyDown: true)
+                    
                 case .keyUp:
                     keyTracker.pressedKeys.remove(keyCode)
-                    SoundManager.shared.playSound(for: keyCode, isKeyDown: false)
-
+                    SoundEngine.shared.play(for: keyCode, isKeyDown: false)
+                    
                 case .flagsChanged:
                     // Respect the user setting to ignore modifier key sounds
-                    if SettingsManager.shared.disableModifierKeys {
+                    if SettingsEngine.shared.isModifierKeySoundDisabled() {
                         return Unmanaged.passUnretained(event)
                     }
                     
                     if keyTracker.pressedKeys.remove(keyCode) == nil {
                         keyTracker.pressedKeys.insert(keyCode)
-                        SoundManager.shared.playSound(for: keyCode, isKeyDown: true)
+                        SoundEngine.shared.play(for: keyCode, isKeyDown: true)
                     } else {
-                        SoundManager.shared.playSound(for: keyCode, isKeyDown: false)
+                        SoundEngine.shared.play(for: keyCode, isKeyDown: false)
                     }
                 default:
                     break
+                    
                 }
-
                 return Unmanaged.passUnretained(event)
             },
             userInfo: observer
@@ -90,9 +92,9 @@ class KeyTracker {
             self.eventMonitor = nil
         }
     }
-
+    
     // MARK: Private methods
-
+    
     private func currentTime() -> Double {
         Double(DispatchTime.now().uptimeNanoseconds) / 1_000_000
     }

--- a/Thock/Services/PipeListenerService.swift
+++ b/Thock/Services/PipeListenerService.swift
@@ -1,0 +1,128 @@
+//
+//  PipeListenerService.swift
+//  Thock
+//
+//  Created by Kamil Łobiński on 28/03/2025.
+//
+
+import Foundation
+
+final class PipeListenerService {
+    static let shared = PipeListenerService()
+    
+    private let pipePath: String
+    
+    private init() {
+        let supportDir = FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/thock")
+        if !FileManager.default.fileExists(atPath: supportDir.path) {
+            try? FileManager.default.createDirectory(at: supportDir, withIntermediateDirectories: true)
+        }
+        
+        self.pipePath = supportDir.appendingPathComponent("thock.pipe").path
+        createPipe()
+        startListening()
+    }
+    
+    private func createPipe() {
+        if FileManager.default.fileExists(atPath: pipePath) {
+            try? FileManager.default.removeItem(atPath: pipePath)
+        }
+        
+        let result = pipePath.withCString { mkfifo($0, 0o600) }
+        if result != 0 {
+            perror("[PIPE] Failed to create")
+        }
+    }
+    
+    private func startListening() {
+        DispatchQueue.global(qos: .background).async { [pipePath] in
+            print("[PIPE] Listener started at \(pipePath)")
+            
+            while true {
+                let fd = open(pipePath, O_RDONLY)
+                if fd == -1 {
+                    print("[PIPE] Failed to open \(pipePath)")
+                    sleep(1)
+                    continue
+                }
+                
+                let fileHandle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+                let data = fileHandle.readDataToEndOfFile()
+                
+                if !data.isEmpty,
+                   let command = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) {
+                    print("[COMMAND] Received \(command)")
+                    self.handle(command: command)
+                }
+                
+                fileHandle.closeFile()
+            }
+        }
+    }
+    
+    private func handle(command: String) {
+        let pattern = #"(".*?"|\S+)"#
+        let regex = try! NSRegularExpression(pattern: pattern)
+        let nsrange = NSRange(command.startIndex..., in: command)
+        
+        let matches = regex.matches(in: command, range: nsrange)
+        let components = matches.compactMap {
+            Range($0.range, in: command).map { range in
+                var token = String(command[range])
+                if token.hasPrefix("\"") && token.hasSuffix("\"") {
+                    token = String(token.dropFirst().dropLast())
+                }
+                return token
+            }
+        }
+        
+        guard components.first == "set-mode", components.count >= 2 else {
+            print("[COMMAND] Invalid format")
+            return
+        }
+        
+        let modeName = components[1]
+        var brand: String?
+        var author: String?
+        
+        var index = 2
+        while index < components.count {
+            let key = components[index]
+            let value = index + 1 < components.count ? components[index + 1] : nil
+            
+            switch key {
+            case "-brand":
+                brand = value
+                index += 2
+            case "-author":
+                author = value
+                index += 2
+            default:
+                print("[COMMAND] Unknown flag \(key)")
+                index += 1
+            }
+        }
+        
+        DispatchQueue.main.async {
+            guard let brand = brand, let author = author else {
+                print("[COMMAND] Missing brand or author")
+                return
+            }
+            
+            let mode = ModeDatabase().getMode(byName: modeName, authorName: author, brandName: brand)
+            
+            guard let mode = mode else {
+                print("[COMMAND] Mode \(modeName) not found for author \(author) and brand \(brand)")
+                return
+            }
+            
+            ModeEngine.shared.apply(mode: mode)
+        }
+    }
+    
+    func cleanUp() {
+        try? FileManager.default.removeItem(atPath: pipePath)
+    }
+}

--- a/cli/thock-cli
+++ b/cli/thock-cli
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+PIPE="$HOME/Library/Application Support/thock/thock.pipe"
+
+if [[ ! -p "$PIPE" ]]; then
+  echo "Error: Thock pipe not found at: $PIPE"
+  echo "Make sure Thock is running and has created the named pipe."
+  exit 1
+fi
+
+# Build the command by wrapping all args in double quotes
+COMMAND=""
+for arg in "$@"; do
+  # Escape any embedded double quotes inside the arg
+  escaped_arg="${arg//\"/\\\"}"
+  COMMAND+="\"$escaped_arg\" "
+done
+
+# Trim trailing space
+COMMAND="${COMMAND%% }"
+
+echo "$COMMAND" > "$PIPE"


### PR DESCRIPTION
* Introduced PipeListenerService to listen for incoming commands
* Enabled mode switching via terminal or shell scripts
* Commands are parsed and passed to existing engine logic
* Deep code cleanup & reorganization (introduced dedicated engine classes)
* Added toggle to ignore rapid key events via menu bar

This turned into a bigger refactor than expected - but script support required touching parts of MenuBarController and various managers, so this was a good moment to reorganize things for clarity and maintainability

Example usage
```sh
echo 'set-mode "Black" --brand "Cherry MX" --author "tplai"' > ~/Library/Application\ Support/thock/thock.pipe
```