### PR TITLE
fix: implement volume persistence using UserDefaults

### DIFF
--- a/Thock/Engines/SoundEngine.swift
+++ b/Thock/Engines/SoundEngine.swift
@@ -1,16 +1,20 @@
-//
-//  SoundEngine.swift
-//  Thock
-//
-//  Created by Kamil Łobiński on 29/03/2025.
-//
-
 import Foundation
+
+extension UserDefaults {
+    static let volumeKey = "appVolume"
+}
 
 final class SoundEngine {
     static let shared = SoundEngine()
     
-    private init() {}
+    private init() {
+        let savedVolume = UserDefaults.standard.float(forKey: UserDefaults.volumeKey)
+        if savedVolume > 0 {
+            SoundManager.shared.setVolume(savedVolume)
+        } else {
+            SoundManager.shared.setVolume(1.0)
+        }
+    }
     private var pitchVariation: Float = 0.0
     
     
@@ -45,6 +49,7 @@ final class SoundEngine {
     func setVolume(_ volume: Float) {
         print("Set volume: \(volume)")
         SoundManager.shared.setVolume(volume)
+        UserDefaults.standard.set(volume, forKey: UserDefaults.volumeKey)
     }
     
     func getVolume() -> Float {


### PR DESCRIPTION
This pull request implements a fix for the volume setting reset issue (#35) in the 'thock' application. The solution utilizes `UserDefaults` to persistently save the volume setting across application launches. 

Changes include:
- **Introduction of `UserDefaults.volumeKey`:** A new `UserDefaults` key (`appVolume`) has been defined for storing the volume.
- **`setVolume` modification:** The `setVolume` function in `SoundEngine.swift` now saves the current volume to `UserDefaults` after it's set.
- **`SoundEngine` initialization update:** The `init` function of `SoundEngine` now retrieves the saved volume from `UserDefaults` on launch. If no saved volume is found, it defaults to the maximum volume (1.0).

This ensures that the user's volume preference is retained between sessions, resolving the reported issue.