### PR TITLE
feat: add volume settings persistence through output device changes

### DIFF
--- a/Thock/Engines/SoundEngine.swift
+++ b/Thock/Engines/SoundEngine.swift
@@ -9,10 +9,7 @@ final class SoundEngine {
     static let shared = SoundEngine()
     
     private init() {
-        let deviceUID = SoundManager.shared.getCurrentOutputDeviceUID()
-        let perDeviceVolumes = UserDefaults.standard.dictionary(forKey: UserDefaults.perDeviceVolumeKey) as? [String: Float] ?? [:]
-        let savedVolume = perDeviceVolumes[deviceUID] ?? 1.0
-        SoundManager.shared.setVolume(savedVolume)
+        SoundManager.shared.applyPerDeviceVolume()
     }
     private var pitchVariation: Float = 0.0
     

--- a/Thock/Managers/SoundManager.swift
+++ b/Thock/Managers/SoundManager.swift
@@ -56,6 +56,14 @@ class SoundManager {
         pitchNode.pitch = pitch
     }
     
+    /// Applies the saved volume for the current output device.
+    func applyPerDeviceVolume() {
+        let deviceUID = getCurrentOutputDeviceUID()
+        let perDeviceVolumes = UserDefaults.standard.dictionary(forKey: UserDefaults.perDeviceVolumeKey) as? [String: Float] ?? [:]
+        let savedVolume = perDeviceVolumes[deviceUID] ?? 1.0
+        mixer.outputVolume = savedVolume
+    }
+    
     private func setupAudioEngine() {
         mixer.outputVolume = 0.5
         engine.attach(pitchNode)
@@ -101,6 +109,9 @@ class SoundManager {
         }
         
         startAudioEngine()
+        
+        // Apply per-device volume after reconfiguring the engine
+        applyPerDeviceVolume()
     }
     
     /// Stops and detaches all existing audio nodes to prevent memory leaks.


### PR DESCRIPTION
With these changes now you'll be able to persist your sound settings per each output device across changes, each device will remember its own volume you set so you can have diff volume for each one

- Add DeviceVolumeSettings model to store per-device volume settings
- Modify SoundEngine to handle per-device volume persistence
- Update SoundManager to manage device-specific volume settings

Closes #18"