### PR TITLE
fix: voiceover activation of menu bar item

### DIFF
--- a/Thock/Views/MenuBarController.swift
+++ b/Thock/Views/MenuBarController.swift
@@ -455,8 +455,11 @@ class MenuBarController {
     // MARK: - Actions
     
     @objc private func onStatusBarIconClick(sender: NSStatusBarButton) {
-        guard let event = NSApp.currentEvent else { return }
-        
+        guard let event = NSApp.currentEvent else {
+            handleLeftClick(sender: sender)
+            return
+        }
+
         switch event.type {
         case .rightMouseUp:
             handleRightClick(sender: sender)


### PR DESCRIPTION
The menu bar button wasn't responding when activated through VoiceOver.

When VoiceOver activates the button, NSApp.currentEvent is nil. The existing code returned early in this case, so the menu wouldn't open. This change handles that case and opens the menu.

Tested on macOS 26.2.