### PR TITLE
Add constant volume output setting

### DIFF
--- a/Thock/Engines/SettingsEngine.swift
+++ b/Thock/Engines/SettingsEngine.swift
@@ -170,6 +170,15 @@ final class SettingsEngine {
         setVolume(volume, for: deviceUID)
     }
     
+    func isConstantVolumeEnabled() -> Bool {
+        return SettingsManager.shared.constantVolumeEnabled
+    }
+
+    func setConstantVolume(_ enabled: Bool) {
+        SettingsManager.shared.constantVolumeEnabled = enabled
+        NotificationCenter.default.post(name: .settingsDidChange, object: nil)
+    }
+
     // MARK: - Pitch Variation
     
     func getPitchVariation() -> Float {

--- a/Thock/Helpers/Localization.swift
+++ b/Thock/Helpers/Localization.swift
@@ -261,6 +261,32 @@ struct L10n {
         }
     }
     
+    static var constantVolume: String {
+        switch lang {
+        case .english: return "Constant volume"
+        case .spanish: return "Volumen constante"
+        case .french: return "Volume constant"
+        case .chinese: return "恒定音量"
+        case .japanese: return "一定音量"
+        case .german: return "Konstante Lautstärke"
+        case .vietnamese: return "Âm lượng không đổi"
+        case .italian: return "Volume costante"
+        }
+    }
+
+    static var constantVolumeSubtitle: String {
+        switch lang {
+        case .english: return "Compensate for system output volume changes while keeping Thock's volume setting"
+        case .spanish: return "Compensa los cambios del volumen del sistema manteniendo el volumen de Thock"
+        case .french: return "Compense les changements de volume du système tout en conservant le volume de Thock"
+        case .chinese: return "在保持 Thock 音量设置的同时补偿系统输出音量变化"
+        case .japanese: return "Thock の音量設定を保ちながらシステム出力音量の変化を補正"
+        case .german: return "Gleicht Änderungen der Systemlautstärke aus und behält Thocks Lautstärke bei"
+        case .vietnamese: return "Bù thay đổi âm lượng hệ thống trong khi giữ cài đặt âm lượng của Thock"
+        case .italian: return "Compensa le modifiche al volume di sistema mantenendo il volume di Thock"
+        }
+    }
+
     static var playThrough: String {
         switch lang {
         case .english: return "Play sound effects through"

--- a/Thock/Managers/AudioDeviceManager.swift
+++ b/Thock/Managers/AudioDeviceManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreAudio
+import AudioToolbox
 import OSLog
 
 final class AudioDeviceManager {
@@ -80,6 +81,18 @@ final class AudioDeviceManager {
         return availableDevices.first { $0.id == uid }
     }
     
+    func getOutputVolume(forUID uid: String?) -> Float? {
+        let deviceID: AudioDeviceID?
+        if let uid {
+            deviceID = findDevice(byUID: uid)?.deviceID
+        } else {
+            deviceID = getSystemDefaultDeviceID()
+        }
+
+        guard let deviceID else { return nil }
+        return getOutputVolume(for: deviceID)
+    }
+
     /// Starts monitoring for device changes
     func startMonitoring() {
         guard !isMonitoring else { return }
@@ -304,6 +317,106 @@ final class AudioDeviceManager {
         return status == noErr ? defaultDeviceID : nil
     }
     
+    private func getOutputVolume(for deviceID: AudioDeviceID) -> Float? {
+        if let decibelVolume = getOutputDecibelVolume(for: deviceID) {
+            return decibelVolume
+        }
+
+        if let virtualMasterVolume = getVirtualMasterOutputVolume(for: deviceID) {
+            return virtualMasterVolume
+        }
+
+        return getScalarOutputVolume(for: deviceID)
+    }
+
+    private func getOutputDecibelVolume(for deviceID: AudioDeviceID) -> Float? {
+        var propertyAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeDecibels,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        guard AudioObjectHasProperty(deviceID, &propertyAddress) else {
+            return nil
+        }
+
+        var decibels = Float32(0)
+        var dataSize = UInt32(MemoryLayout<Float32>.size)
+        let status = AudioObjectGetPropertyData(
+            deviceID,
+            &propertyAddress,
+            0,
+            nil,
+            &dataSize,
+            &decibels
+        )
+
+        guard status == noErr else {
+            return nil
+        }
+
+        let linearVolume = pow(10.0, decibels / 20.0)
+        return max(0.0, min(1.0, linearVolume))
+    }
+
+    private func getVirtualMasterOutputVolume(for deviceID: AudioDeviceID) -> Float? {
+        var propertyAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwareServiceDeviceProperty_VirtualMainVolume,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        guard AudioObjectHasProperty(deviceID, &propertyAddress) else {
+            return nil
+        }
+
+        var volume = Float32(0)
+        var dataSize = UInt32(MemoryLayout<Float32>.size)
+        let status = AudioObjectGetPropertyData(
+            deviceID,
+            &propertyAddress,
+            0,
+            nil,
+            &dataSize,
+            &volume
+        )
+
+        guard status == noErr else {
+            return nil
+        }
+
+        return max(0.0, min(1.0, volume))
+    }
+
+    private func getScalarOutputVolume(for deviceID: AudioDeviceID) -> Float? {
+        var propertyAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioDevicePropertyScopeOutput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        guard AudioObjectHasProperty(deviceID, &propertyAddress) else {
+            return nil
+        }
+
+        var volume = Float32(0)
+        var dataSize = UInt32(MemoryLayout<Float32>.size)
+        let status = AudioObjectGetPropertyData(
+            deviceID,
+            &propertyAddress,
+            0,
+            nil,
+            &dataSize,
+            &volume
+        )
+
+        guard status == noErr else {
+            return nil
+        }
+
+        return max(0.0, min(1.0, volume))
+    }
+
     // MARK: - Private Methods - Device Monitoring
     
     private func setupDeviceListListener() {

--- a/Thock/Managers/SettingsManager.swift
+++ b/Thock/Managers/SettingsManager.swift
@@ -12,6 +12,7 @@ final class SettingsManager {
     static let defaultAudioBufferSize: UInt32 = 256
     static let defaultSelectedAudioDeviceUID: String? = nil
     static let defaultPerDeviceVolumes: [String: Float] = [:]
+    static let defaultConstantVolumeEnabled: Bool = false
     static let defaultPitchVariation: Float = 0.0
     static let defaultMouseSoundEnabled: Bool = false
     static let defaultAutoEnableOnHeadphone: Bool = false
@@ -69,6 +70,12 @@ final class SettingsManager {
         set { UserDefaults.perDeviceVolumes = newValue }
     }
     
+    /// Whether Thock compensates for output device volume changes.
+    var constantVolumeEnabled: Bool {
+        get { UserDefaults.constantVolumeEnabled }
+        set { UserDefaults.constantVolumeEnabled = newValue }
+    }
+
     /// Pitch variation range in semitones for random pitch shifts.
     var pitchVariation: Float {
         get { UserDefaults.pitchVariation }
@@ -104,6 +111,7 @@ private extension UserDefaults {
         static let audioBufferSize = "audioBufferSize"
         static let selectedAudioDeviceUID = "selectedAudioDeviceUID"
         static let perDeviceVolumes = "perDeviceVolume"
+        static let constantVolumeEnabled = "constantVolumeEnabled"
         static let pitchVariation = "pitchVariation"
         static let mouseSoundEnabled = "mouseSoundEnabled"
         static let autoEnableOnHeadphone = "autoEnableOnHeadphone"
@@ -205,6 +213,18 @@ private extension UserDefaults {
         }
     }
     
+    static var constantVolumeEnabled: Bool {
+        get {
+            if standard.object(forKey: Keys.constantVolumeEnabled) == nil {
+                return SettingsManager.defaultConstantVolumeEnabled
+            }
+            return standard.bool(forKey: Keys.constantVolumeEnabled)
+        }
+        set {
+            standard.set(newValue, forKey: Keys.constantVolumeEnabled)
+        }
+    }
+
     static var pitchVariation: Float {
         get {
             if standard.object(forKey: Keys.pitchVariation) == nil {

--- a/Thock/Managers/SoundManager.swift
+++ b/Thock/Managers/SoundManager.swift
@@ -45,6 +45,8 @@ final class SoundManager {
     
     // MARK: - Volume Control
     private var volume: Float = 0.5
+    private var systemOutputVolume: Float = 1.0
+    private var constantVolumeEnabled = false
     private let volumeLock = NSLock()
     
     // MARK: - Models
@@ -123,6 +125,7 @@ final class SoundManager {
         
         // Initialize volume from settings
         updateVolumeFromSettings()
+        updateSystemOutputVolume()
         
         // Start monitoring audio device changes
         AudioDeviceManager.shared.startMonitoring()
@@ -130,6 +133,7 @@ final class SoundManager {
     
     @objc private func handleSettingsChange() {
         let newBufferSize = SettingsManager.shared.audioBufferSize
+        updateVolumeFromSettings()
         
         // Handle buffer size change
         if newBufferSize != currentBufferSize {
@@ -198,9 +202,11 @@ final class SoundManager {
     private func updateVolumeFromSettings(postNotification: Bool = false) {
         let deviceUID = getCurrentOutputDeviceUID()
         let newVolume = SettingsEngine.shared.getVolume(for: deviceUID)
+        let newConstantVolumeEnabled = SettingsEngine.shared.isConstantVolumeEnabled()
         
         volumeLock.lock()
         volume = newVolume
+        constantVolumeEnabled = newConstantVolumeEnabled
         volumeLock.unlock()
         
         if postNotification {
@@ -208,6 +214,31 @@ final class SoundManager {
         }
     }
     
+    private func updateSystemOutputVolume() {
+        let selectedUID = SettingsEngine.shared.getSelectedAudioDeviceUID()
+        let newSystemVolume = AudioDeviceManager.shared.getOutputVolume(forUID: selectedUID) ?? 1.0
+
+        volumeLock.lock()
+        systemOutputVolume = newSystemVolume
+        volumeLock.unlock()
+    }
+
+    private func currentRenderVolume() -> Float {
+        let appVolume = volume
+
+        guard constantVolumeEnabled else {
+            return appVolume
+        }
+
+        let minimumSystemVolume: Float = 0.01
+        let maximumGain: Float = 2.0
+        let compensationExponent: Float = 1.08
+        let outputVolume = max(systemOutputVolume, minimumSystemVolume)
+        let compensatedVolume = appVolume / pow(outputVolume, compensationExponent)
+
+        return min(compensatedVolume, maximumGain)
+    }
+
     private func reinitializeAudioQueue(with newBufferSize: UInt32, isRetry: Bool = false) {
         detectHardwareSampleRate()
         
@@ -622,7 +653,7 @@ final class SoundManager {
         memset(outputBuffer, 0, Int(framesPerBuffer * audioFormat.mBytesPerFrame))
         
         // No lock here coz float reads are atomic
-        let currentVolume = volume
+        let currentVolume = currentRenderVolume()
         
         for sound in activeSounds {
             // Report playback started on first render
@@ -771,6 +802,8 @@ final class SoundManager {
             recordLatencyCheckpoint(latencyId, point: .bufferScheduling)
         }
         
+        updateSystemOutputVolume()
+
         // Gen pitch offset [-variation, +variation]
         let pitchOffset: Float
         if pitchVariation > 0.0 {
@@ -878,6 +911,7 @@ final class SoundManager {
         
         // Get pitch variation
         let pitchVariation = SettingsEngine.shared.getPitchVariation()
+        updateSystemOutputVolume()
         
         let pitchOffset: Float
         if pitchVariation > 0.0 {

--- a/Thock/Views/Settings/SoundSettingsView.swift
+++ b/Thock/Views/Settings/SoundSettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SoundSettingsView: View {
     @State private var volume = Double(SettingsEngine.shared.getVolume())
+    @State private var constantVolumeEnabled = SettingsEngine.shared.isConstantVolumeEnabled()
     @State private var disableModifierKeys = SettingsEngine.shared.isModifierKeySoundDisabled()
     @State private var ignoreRapidKeyEvents = SettingsEngine.shared.isIgnoreRapidKeyEventsEnabled()
     @State private var autoMuteOnMusicPlayback = SettingsEngine.shared.isAutoMuteOnMusicPlaybackEnabled()
@@ -38,6 +39,20 @@ struct SoundSettingsView: View {
                         )
                     )
                     
+                    SettingsRowView(
+                        title: L10n.constantVolume,
+                        subtitle: L10n.constantVolumeSubtitle,
+                        control: AnyView(
+                            Toggle("", isOn: $constantVolumeEnabled)
+                                .toggleStyle(.switch)
+                                .controlSize(.small)
+                                .labelsHidden()
+                                .onChange(of: constantVolumeEnabled) { newValue in
+                                    SettingsEngine.shared.setConstantVolume(newValue)
+                                }
+                        )
+                    )
+
                     SettingsRowView(
                         title: L10n.playThrough,
                         subtitle: nil,
@@ -201,6 +216,7 @@ struct SoundSettingsView: View {
             selectedDeviceUID = SettingsEngine.shared.getSelectedAudioDeviceUID() ?? "system-default"
         }
         .onReceive(NotificationCenter.default.publisher(for: .settingsDidChange)) { _ in
+            constantVolumeEnabled = SettingsEngine.shared.isConstantVolumeEnabled()
             disableModifierKeys = SettingsEngine.shared.isModifierKeySoundDisabled()
             ignoreRapidKeyEvents = SettingsEngine.shared.isIgnoreRapidKeyEventsEnabled()
             autoMuteOnMusicPlayback = SettingsEngine.shared.isAutoMuteOnMusicPlaybackEnabled()
@@ -239,4 +255,3 @@ struct SoundSettingsView: View {
     SoundSettingsView()
         .frame(width: 500, height: 600)
 }
-


### PR DESCRIPTION
- Adds a new Output setting for Constant volume, off by default
- Compensates Thock playback gain against the current system output volume
- Reads output volume from CoreAudio, preferring dB volume and falling back to virtual/scalar volume properties
- Keeps compensation internal to Thock without changing macOS system volume

Fixes #74