### PR TITLE
feat: preview a soundpack before installing it

### DIFF
--- a/Thock/Services/SoundpackPreviewPlayer.swift
+++ b/Thock/Services/SoundpackPreviewPlayer.swift
@@ -1,0 +1,94 @@
+import AVFoundation
+import Foundation
+import OSLog
+
+/// Plays a short burst of keystrokes from a soundpack folder, so a soundpack can be
+/// heard before it is installed.
+///
+/// Deliberately independent of `SoundManager`: a preview must not touch the audio queue
+/// or the preloaded sounds of the soundpack the user is actually typing with.
+@MainActor
+final class SoundpackPreviewPlayer {
+    static let shared = SoundpackPreviewPlayer()
+
+    enum PreviewError: Error {
+        case noSounds
+    }
+
+    private static let keystrokeCount = 6
+    private static let keystrokeInterval: TimeInterval = 0.18
+    private static let keyUpDelay: TimeInterval = 0.09
+    private static let leadTime: TimeInterval = 0.1
+
+    private var players: [AVAudioPlayer] = []
+
+    private init() {}
+
+    /// Schedules a preview of the soundpack in `packDirectory`.
+    ///
+    /// The audio is held in memory, so the caller may delete a temporary soundpack
+    /// directory as soon as this returns.
+    ///
+    /// - Returns: how long the scheduled preview will take to finish playing.
+    @discardableResult
+    func play(packDirectory: URL) throws -> TimeInterval {
+        stop()
+
+        let configURL = packDirectory.appendingPathComponent("config.json")
+        let config = try JSONDecoder().decode(SoundpackConfig.self, from: Data(contentsOf: configURL))
+
+        // "default" is the fallback group for keyboard packs; mouse packs only have named ones.
+        guard let group = config.sounds["default"] ?? config.sounds.values.first, !group.down.isEmpty else {
+            throw PreviewError.noSounds
+        }
+
+        let volume = SettingsEngine.shared.getVolume()
+        var scheduled: [(offset: TimeInterval, player: AVAudioPlayer)] = []
+
+        for index in 0..<Self.keystrokeCount {
+            let offset = Double(index) * Self.keystrokeInterval
+            if let file = group.down.randomElement(),
+               let player = makePlayer(directory: packDirectory, file: file, volume: volume) {
+                scheduled.append((offset, player))
+            }
+            if let file = group.up.randomElement(),
+               let player = makePlayer(directory: packDirectory, file: file, volume: volume) {
+                scheduled.append((offset + Self.keyUpDelay, player))
+            }
+        }
+
+        // `deviceCurrentTime` is a shared output clock, so one reading lines every sound up.
+        guard let start = scheduled.first?.player.deviceCurrentTime else {
+            throw PreviewError.noSounds
+        }
+
+        for (offset, player) in scheduled {
+            player.play(atTime: start + Self.leadTime + offset)
+        }
+        players = scheduled.map(\.player)
+
+        let lastKeystroke = Double(Self.keystrokeCount - 1) * Self.keystrokeInterval + Self.keyUpDelay
+        let longestSound = players.map(\.duration).max() ?? 0
+        return Self.leadTime + lastKeystroke + longestSound
+    }
+
+    func stop() {
+        players.forEach { $0.stop() }
+        players.removeAll()
+    }
+
+    // MARK: - Private
+
+    private func makePlayer(directory: URL, file: String, volume: Float) -> AVAudioPlayer? {
+        do {
+            let data = try Data(contentsOf: directory.appendingPathComponent(file))
+            let player = try AVAudioPlayer(data: data)
+            player.volume = volume
+            player.prepareToPlay()
+            return player
+        } catch {
+            Logger.engine.error("Preview could not load '\(file)': \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Thock/Services/SoundpackRegistryService.swift
+++ b/Thock/Services/SoundpackRegistryService.swift
@@ -9,6 +9,7 @@ final class SoundpackRegistryService: ObservableObject {
     @Published var isLoading = false
     @Published var errorMessage: String? = nil
     @Published var downloadingIds: Set<UUID> = []
+    @Published var previewingIds: Set<UUID> = []
     @Published var installedIds: Set<UUID> = []
     @Published var customKeyboardSoundpacks: [Soundpack] = []
     @Published var customMouseSoundpacks: [Soundpack] = []
@@ -49,15 +50,7 @@ final class SoundpackRegistryService: ObservableObject {
             let destination = customSoundsDirectory()
                 .appendingPathComponent(entry.id.uuidString, isDirectory: true)
             
-            try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
-            
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
-            process.arguments = ["-x", "-k", tempURL.path, destination.path]
-            try process.run()
-            process.waitUntilExit()
-            
-            try? FileManager.default.removeItem(at: tempURL)
+            try unzip(tempURL, to: destination)
             
             refreshInstalledIds()
             
@@ -81,6 +74,54 @@ final class SoundpackRegistryService: ObservableObject {
         downloadingIds.remove(entry.id)
     }
     
+    /// Plays a few keystrokes from a registry soundpack. Nothing is installed: a pack the
+    /// user doesn't have is unpacked into a temporary directory that is removed right after.
+    func preview(_ entry: SoundpackRegistryEntry) async {
+        guard !previewingIds.contains(entry.id), !downloadingIds.contains(entry.id) else { return }
+        previewingIds.insert(entry.id)
+
+        let installed = customSoundsDirectory().appendingPathComponent(entry.id.uuidString, isDirectory: true)
+        var temporary: URL? = nil
+
+        do {
+            let directory: URL
+            if FileManager.default.fileExists(atPath: installed.appendingPathComponent("config.json").path) {
+                directory = installed
+            } else {
+                guard let downloadURL = URL(string: entry.download.url) else { throw URLError(.badURL) }
+                let (tempURL, _) = try await URLSession.shared.download(from: downloadURL)
+                let unpacked = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("ThockPreview-\(entry.id.uuidString)", isDirectory: true)
+                try unzip(tempURL, to: unpacked)
+                directory = unpacked
+                temporary = unpacked
+            }
+
+            try await playPreview(in: directory)
+        } catch {
+            print("Failed to preview soundpack \(entry.metadata.name): \(error)")
+        }
+
+        if let temporary {
+            try? FileManager.default.removeItem(at: temporary)
+        }
+        previewingIds.remove(entry.id)
+    }
+
+    /// Plays a few keystrokes from an installed custom soundpack.
+    func previewCustom(_ soundpack: Soundpack) async {
+        guard !previewingIds.contains(soundpack.id) else { return }
+        previewingIds.insert(soundpack.id)
+
+        do {
+            try await playPreview(in: customSoundpackDirectory(for: soundpack))
+        } catch {
+            print("Failed to preview soundpack \(soundpack.name): \(error)")
+        }
+
+        previewingIds.remove(soundpack.id)
+    }
+
     func uninstall(_ entry: SoundpackRegistryEntry) {
         let folder = customSoundsDirectory().appendingPathComponent(entry.id.uuidString)
         try? FileManager.default.removeItem(at: folder)
@@ -109,10 +150,7 @@ final class SoundpackRegistryService: ObservableObject {
     }
     
     func uninstallCustom(_ soundpack: Soundpack) {
-        let base = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Application Support/Thock")
-        let folder = base.appendingPathComponent(soundpack.path)
-        try? FileManager.default.removeItem(at: folder)
+        try? FileManager.default.removeItem(at: customSoundpackDirectory(for: soundpack))
         SoundpackEngine.shared.reloadAfterRemoval(for: soundpack.category)
         refreshInstalledIds()
         refreshCustomSoundpacks()
@@ -121,6 +159,30 @@ final class SoundpackRegistryService: ObservableObject {
     
     private func customSoundsDirectory() -> URL {
         return CustomSoundpackHelper.getCustomSoundpackDirectory()
+    }
+
+    private func customSoundpackDirectory(for soundpack: Soundpack) -> URL {
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/Thock")
+            .appendingPathComponent(soundpack.path)
+    }
+
+    private func unzip(_ archive: URL, to destination: URL) throws {
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+        process.arguments = ["-x", "-k", archive.path, destination.path]
+        try process.run()
+        process.waitUntilExit()
+
+        try? FileManager.default.removeItem(at: archive)
+    }
+
+    /// Waits for the preview to finish so the row keeps showing its playing state.
+    private func playPreview(in directory: URL) async throws {
+        let duration = try SoundpackPreviewPlayer.shared.play(packDirectory: directory)
+        try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
     }
 }
 

--- a/Thock/Views/Settings/SoundpacksSettingsView.swift
+++ b/Thock/Views/Settings/SoundpacksSettingsView.swift
@@ -76,16 +76,20 @@ struct SoundpacksSettingsView: View {
                             entry: entry,
                             isInstalled: true,
                             isDownloading: service.downloadingIds.contains(entry.id),
+                            isPreviewing: service.previewingIds.contains(entry.id),
                             isLast: false,
                             onInstall: { Task { await service.install(entry) } },
-                            onUninstall: { service.uninstall(entry) }
+                            onUninstall: { service.uninstall(entry) },
+                            onPreview: { Task { await service.preview(entry) } }
                         )
                     }
                     ForEach(Array(customKeyboard.enumerated()), id: \.element.id) { index, soundpack in
                         SoundpackCustomRowView(
                             soundpack: soundpack,
+                            isPreviewing: service.previewingIds.contains(soundpack.id),
                             isLast: index == customKeyboard.count - 1 && uninstalledKeyboard.isEmpty && !keyboardHasInlineState,
-                            onUninstall: { service.uninstallCustom(soundpack) }
+                            onUninstall: { service.uninstallCustom(soundpack) },
+                            onPreview: { Task { await service.previewCustom(soundpack) } }
                         )
                     }
                     ForEach(Array(uninstalledKeyboard.enumerated()), id: \.element.id) { index, entry in
@@ -93,9 +97,11 @@ struct SoundpacksSettingsView: View {
                             entry: entry,
                             isInstalled: false,
                             isDownloading: service.downloadingIds.contains(entry.id),
+                            isPreviewing: service.previewingIds.contains(entry.id),
                             isLast: index == uninstalledKeyboard.count - 1,
                             onInstall: { Task { await service.install(entry) } },
-                            onUninstall: { service.uninstall(entry) }
+                            onUninstall: { service.uninstall(entry) },
+                            onPreview: { Task { await service.preview(entry) } }
                         )
                     }
                     if keyboardRegistryEmpty && customKeyboard.isEmpty {
@@ -147,16 +153,20 @@ struct SoundpacksSettingsView: View {
                             entry: entry,
                             isInstalled: true,
                             isDownloading: service.downloadingIds.contains(entry.id),
+                            isPreviewing: service.previewingIds.contains(entry.id),
                             isLast: false,
                             onInstall: { Task { await service.install(entry) } },
-                            onUninstall: { service.uninstall(entry) }
+                            onUninstall: { service.uninstall(entry) },
+                            onPreview: { Task { await service.preview(entry) } }
                         )
                     }
                     ForEach(Array(customMouse.enumerated()), id: \.element.id) { index, soundpack in
                         SoundpackCustomRowView(
                             soundpack: soundpack,
+                            isPreviewing: service.previewingIds.contains(soundpack.id),
                             isLast: index == customMouse.count - 1 && uninstalledMouse.isEmpty && !mouseHasInlineState,
-                            onUninstall: { service.uninstallCustom(soundpack) }
+                            onUninstall: { service.uninstallCustom(soundpack) },
+                            onPreview: { Task { await service.previewCustom(soundpack) } }
                         )
                     }
                     ForEach(Array(uninstalledMouse.enumerated()), id: \.element.id) { index, entry in
@@ -164,9 +174,11 @@ struct SoundpacksSettingsView: View {
                             entry: entry,
                             isInstalled: false,
                             isDownloading: service.downloadingIds.contains(entry.id),
+                            isPreviewing: service.previewingIds.contains(entry.id),
                             isLast: index == uninstalledMouse.count - 1,
                             onInstall: { Task { await service.install(entry) } },
-                            onUninstall: { service.uninstall(entry) }
+                            onUninstall: { service.uninstall(entry) },
+                            onPreview: { Task { await service.preview(entry) } }
                         )
                     }
                     if mouseRegistryEmpty && customMouse.isEmpty {
@@ -211,15 +223,22 @@ private struct SoundpackRegistryRowView: View {
     let entry: SoundpackRegistryEntry
     let isInstalled: Bool
     let isDownloading: Bool
+    let isPreviewing: Bool
     let isLast: Bool
     let onInstall: () -> Void
     let onUninstall: () -> Void
-    
+    let onPreview: () -> Void
+
     var body: some View {
         SettingsRowView(
             title: entry.metadata.name,
             subtitle: "\(entry.metadata.brand) · by \(entry.metadata.author) · \(formattedSize)",
-            control: AnyView(actionControl),
+            control: AnyView(
+                HStack(spacing: 10) {
+                    SoundpackPreviewButton(isPreviewing: isPreviewing, action: onPreview)
+                    actionControl
+                }
+            ),
             isLast: isLast
         )
     }
@@ -259,13 +278,39 @@ private struct SoundpackRegistryRowView: View {
     }
 }
 
+// MARK: - Preview Button
+
+private struct SoundpackPreviewButton: View {
+    let isPreviewing: Bool
+    let action: () -> Void
+
+    var body: some View {
+        if isPreviewing {
+            Image(systemName: "speaker.wave.2.fill")
+                .font(.system(size: 15))
+                .foregroundColor(.accentColor)
+                .frame(width: 20, height: 20)
+        } else {
+            Button(action: action) {
+                Image(systemName: "play.circle")
+                    .font(.system(size: 20))
+                    .foregroundColor(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Preview soundpack")
+        }
+    }
+}
+
 // MARK: - Custom Row View
 
 private struct SoundpackCustomRowView: View {
     let soundpack: Soundpack
+    let isPreviewing: Bool
     let isLast: Bool
     let onUninstall: () -> Void
-    
+    let onPreview: () -> Void
+
     private var subtitle: String {
         var parts = ["Custom"]
         if !soundpack.brand.isEmpty { parts.append(soundpack.brand) }
@@ -278,13 +323,17 @@ private struct SoundpackCustomRowView: View {
             title: soundpack.name,
             subtitle: subtitle,
             control: AnyView(
-                Button(action: onUninstall) {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 20))
-                        .foregroundColor(.secondary.opacity(0.6))
-                }
+                HStack(spacing: 10) {
+                    SoundpackPreviewButton(isPreviewing: isPreviewing, action: onPreview)
+
+                    Button(action: onUninstall) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 20))
+                            .foregroundColor(.secondary.opacity(0.6))
+                    }
                     .buttonStyle(.plain)
                     .help("Remove soundpack")
+                }
             ),
             isLast: isLast
         )

--- a/cli/thock-cli
+++ b/cli/thock-cli
@@ -69,6 +69,168 @@ EOF
   exit 0
 fi
 
+# ─── preview (name or UUID, installed or not) ─────────────────────────────────
+
+if [[ "$1" == "preview" ]]; then
+  if [[ -z "$2" ]]; then
+    echo "Usage: thock-cli preview <name|uuid> [--brand <brand>] [--author <author>]"
+    exit 1
+  fi
+
+  INPUT="$2"
+  FILTER_BRAND=""
+  FILTER_AUTHOR=""
+
+  shift 2
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --brand)  FILTER_BRAND="$2";  shift 2 ;;
+      --author) FILTER_AUTHOR="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  python3 - "$SOUNDPACKS_DIR" "$INPUT" "$FILTER_BRAND" "$FILTER_AUTHOR" <<'EOF'
+import io, json, os, random, re, subprocess, sys, tempfile, urllib.request, wave, zipfile
+
+MANIFEST_URL = "https://raw.githubusercontent.com/kamillobinski/thock-soundpacks/refs/heads/main/manifest.json"
+KEYSTROKES = 6
+GAP_SECONDS = 0.06
+
+directory, query, brand, author = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+uuid_re = re.compile(r"^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$")
+
+
+def read_config(text):
+    return json.loads(re.sub(r",\s*([}\]])", r"\1", text))
+
+
+def matches(pack_id, m):
+    if uuid_re.match(query):
+        return pack_id.lower() == query.lower()
+    if m["name"].lower() != query.lower():
+        return False
+    if brand and m.get("brand", "").lower() != brand.lower():
+        return False
+    if author and m.get("author", "").lower() != author.lower():
+        return False
+    return True
+
+
+# Registry entries first - previewing one that isn't installed yet is the point.
+candidates = []
+try:
+    with urllib.request.urlopen(MANIFEST_URL, timeout=20) as response:
+        manifest = json.load(response)
+except Exception as e:
+    print(f"Warning: could not reach the soundpack registry ({e}).")
+    manifest = {}
+
+for entries in manifest.get("soundpacks", {}).values():
+    for e in entries:
+        candidates.append((e["id"], e["metadata"], e["download"]["url"]))
+
+known = {c[0].lower() for c in candidates}
+
+# Plus anything installed the registry doesn't know about (custom soundpacks).
+if os.path.isdir(directory):
+    for name in os.listdir(directory):
+        config_path = os.path.join(directory, name, "config.json")
+        if not os.path.isfile(config_path):
+            continue
+        try:
+            with open(config_path) as f:
+                c = read_config(f.read())
+            if c["id"].lower() not in known:
+                candidates.append((c["id"], c["metadata"], None))
+        except (json.JSONDecodeError, KeyError, OSError):
+            continue
+
+matched = [c for c in candidates if matches(c[0], c[1])]
+
+if len(matched) > 1:
+    print(f"Error: multiple soundpacks match '{query}'. Use --brand or --author to narrow it down.")
+    sys.exit(1)
+if not matched:
+    print(f"Error: no soundpack found matching '{query}'.")
+    sys.exit(1)
+
+pack_id, metadata, download_url = matched[0]
+
+
+def pick_keystrokes(pack_dir):
+    """A few keystrokes, each the sound files to play for it (key down, then key up)."""
+    with open(os.path.join(pack_dir, "config.json")) as f:
+        sounds = read_config(f.read())["sounds"]
+    # "default" is the fallback group for keyboard packs; mouse packs only have named ones.
+    group = sounds.get("default") or next(iter(sounds.values()), {})
+    down, up = group.get("down") or [], group.get("up") or []
+    if not down:
+        return []
+    keystrokes = []
+    for _ in range(KEYSTROKES):
+        files = [random.choice(down)] + ([random.choice(up)] if up else [])
+        keystrokes.append([os.path.join(pack_dir, f) for f in files])
+    return keystrokes
+
+
+def stitch(keystrokes, out_path):
+    """Join the samples into one WAV so playback is a single afplay, not one per sound.
+
+    Spawning afplay per sound costs roughly a second each, which makes the preview
+    sound like laggy typing rather than like the soundpack.
+    """
+    frames, params = [], None
+    for keystroke in keystrokes:
+        for path in keystroke:
+            with wave.open(path) as w:
+                if params is None:
+                    params = w.getparams()
+                elif w.getparams()[:3] != params[:3]:
+                    raise ValueError(f"'{path}' does not match the pack's audio format")
+                frames.append(w.readframes(w.getnframes()))
+        # Silence between keystrokes only, so key down and key up stay paired.
+        frames.append(bytes(int(params.framerate * GAP_SECONDS) * params.nchannels * params.sampwidth))
+    with wave.open(out_path, "wb") as out:
+        out.setparams(params)
+        out.writeframes(b"".join(frames))
+
+
+def play(pack_dir):
+    print(f"Previewing {metadata['name']} by {metadata['author']} ({metadata['brand']})")
+    keystrokes = pick_keystrokes(pack_dir)
+    if not keystrokes:
+        print("Error: this soundpack has no key down sounds to preview.")
+        sys.exit(1)
+    with tempfile.NamedTemporaryFile(suffix=".wav") as stitched:
+        try:
+            stitch(keystrokes, stitched.name)
+        except (wave.Error, ValueError, EOFError):
+            # Custom soundpacks may use formats the wave module can't read (mp3, m4a).
+            for path in (p for keystroke in keystrokes for p in keystroke):
+                subprocess.run(["afplay", path])
+            return
+        subprocess.run(["afplay", stitched.name])
+
+
+installed_dir = os.path.join(directory, pack_id)
+
+if os.path.isfile(os.path.join(installed_dir, "config.json")):
+    play(installed_dir)
+elif download_url:
+    with urllib.request.urlopen(download_url, timeout=60) as response:
+        archive = zipfile.ZipFile(io.BytesIO(response.read()))
+    # Extracted to a temp dir so a preview never installs the soundpack.
+    with tempfile.TemporaryDirectory() as tmp:
+        archive.extractall(tmp)
+        play(tmp)
+else:
+    print(f"Error: soundpack '{query}' is not installed and has no download URL.")
+    sys.exit(1)
+EOF
+  exit $?
+fi
+
 # ─── set-soundpack (name or UUID) ─────────────────────────────────────────────
 
 if [[ "$1" == "set-soundpack" ]]; then


### PR DESCRIPTION
Closes #134

Lets you **hear a soundpack before installing it** — a play button on every row in Settings → Soundpacks, plus a matching CLI command.

## Settings UI

Every registry row gets a play button, whether the pack is installed or not. Pressing it plays ~6 keystrokes; the button becomes a speaker glyph while it plays. Installed custom soundpacks get one too.

For a pack you don't have, the zip is downloaded and unpacked into a temporary directory, played, and the directory is deleted immediately — nothing is installed and the library is untouched.

## Playback

New `SoundpackPreviewPlayer`, deliberately independent of `SoundManager`. Previewing must not touch the live `AudioQueue` or the preloaded sounds of the soundpack the user is actually typing with, so this schedules plain `AVAudioPlayer`s instead of going through the engine:

- Sounds are loaded via `AVAudioPlayer(data:)`, so the audio survives deleting the temporary pack directory the moment scheduling returns.
- One reading of `deviceCurrentTime` plus `play(atTime:)` lines every sound up: keystrokes 180ms apart, key up 90ms after key down.
- Volume comes from `SettingsEngine.getVolume()`, so a preview is as loud as the pack will actually be.
- `default` group for keyboard packs, first group for mouse packs (which only have `left`/`right`).

## CLI

```
thock-cli preview <name|uuid> [--brand <brand>] [--author <author>]
```

Same idea from the terminal, and it doesn't use the named pipe, so it works whether or not Thock is running. Name matching, `--brand`/`--author` narrowing, and the ambiguous/not-found errors mirror `set-soundpack`. If the pack is already installed it plays from disk instead of downloading; installed custom packs resolve too; if the registry is unreachable it warns and falls back to installed packs.

The obvious implementation there (one `afplay` per sound) took ~11.5s and sounded like laggy typing rather than like the soundpack — `afplay` costs roughly a second per spawn. The sampled sounds are stitched into a single WAV with the stdlib `wave` module and played in one call: **~3s including the download**. All 1076 audio files across the 26 registry packs are WAV and readable by `wave`, with a uniform format within each pack; a custom pack using mp3/m4a falls back to one `afplay` per sound. No new dependencies.

## Incidental

`install()`'s inline `ditto` call and `uninstallCustom()`'s path building are now the shared `unzip(_:to:)` and `customSoundpackDirectory(for:)` helpers, since preview needs both. No behaviour change.

## Tested

`xcodebuild` clean. `SoundpackPreviewPlayer` was also exercised outside the app against real registry packs (keyboard mono, keyboard stereo, mouse), including deleting the pack directory mid-preview to confirm the in-memory invariant holds.

CLI, against the live registry: mono/stereo/mouse packs, by name and by UUID, ambiguous name, `--brand` and `--author` narrowing, unknown name, missing argument, already-installed pack, installed custom pack, registry unreachable with and without a local copy, an m4a pack hitting the `afplay` fallback, and a pack whose sound group has no key down sounds.

I did **not** click the button in a running build — I have Thock installed and running here, and a second instance would fight the first for the named pipe and the global event tap. Worth a quick manual check on your side.

## Notes

- The docs site will need a `Command: preview` page under CLI; happy to send that.
- A matching **Preview Soundpack** command for the Raycast extension is up at raycast/extensions#29786, held as a draft until a `thock-cli` with `preview` ships.
